### PR TITLE
Issue 4 - Accept connection parameters from a plain object

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -9,10 +9,11 @@ var PreparedStatement = require('./preparedStatement');
 
 
 class Connection {
-    constructor(connectionString, driver) {
-        this.__base = ParseConnection(connectionString, driver);
+
+    constructor(conn, driver) {
+        this.__base = 'string' === typeof conn ? ParseConnection(conn, driver) : conn;
         this.__connection = this.__base.Driver.open(this.__base);
-        this.__connectionUrl = connectionString;
+        this.__connectionUrl = 'string' === typeof conn ? conn : conn.makeURL();
         this.__driver = driver || this.__base.Driver;
     }
 

--- a/lib/connectionObject.js
+++ b/lib/connectionObject.js
@@ -5,6 +5,7 @@
  * @class ConnectionObject
  */
 class ConnectionObject {
+
     /**
      * Creates an instance of ConnectionObject.
      * @param {string} driverName 
@@ -18,6 +19,7 @@ class ConnectionObject {
      * @memberof ConnectionObject
      */
     constructor(driverName, username, password, hostname, port, database, parameters, driver) {
+        this.DriverName = driverName;
         this.Driver = driver || require(driverName);
         this.Username = username;
         this.Password = password;
@@ -43,6 +45,45 @@ class ConnectionObject {
 
         return results;
     }
+
+    /**
+     * Makes a URL from the parameters.
+     * 
+     * @return {string}
+     * @memberof ConnectionObject
+     */
+    makeURL() {
+        return this.DriverName + '://' +
+            ( this.Username ? this.Username + ':' : '' ) +
+            ( this.Password ? this.Password : '' ) +
+            ( this.Hostname ? '@' + this.Hostname : '' ) +
+            ( this.Port ? ':' + this.Port : '' ) +
+            '/' + this.Database +
+            ( this.Parameters ? '?' + this.parseParameters() : '' )
+            ;
+    }
+
+    /**
+     * Creates a new connection object from a plain object.
+     * 
+     * @param {object} obj 
+     * @param {any} driver 
+     * @returns {ConnectionObject}
+     * @memberof ConnectionObject
+     */
+    static fromPlain( obj, driver ) {
+        return new ConnectionObject(
+            obj[ 'driverName' ], 
+            obj[ 'username' ],
+            obj[ 'password' ],
+            obj[ 'hostname' ],
+            obj[ 'port' ],
+            obj[ 'database' ],
+            obj[ 'parameters' ],
+            driver
+        );
+    }
+
 }
 
 module.exports = ConnectionObject;

--- a/lib/connectionObject.js
+++ b/lib/connectionObject.js
@@ -54,8 +54,8 @@ class ConnectionObject {
      */
     makeURL() {
         return this.DriverName + '://' +
-            ( this.Username ? this.Username + ':' : '' ) +
-            ( this.Password ? this.Password : '' ) +
+            ( this.Username ? this.Username : '' ) +
+            ( this.Password ? ':' + this.Password : '' ) +
             ( this.Hostname ? '@' + this.Hostname : '' ) +
             ( this.Port ? ':' + this.Port : '' ) +
             '/' + this.Database +

--- a/lib/connectionObject.js
+++ b/lib/connectionObject.js
@@ -73,13 +73,13 @@ class ConnectionObject {
      */
     static fromPlain( obj, driver ) {
         return new ConnectionObject(
-            obj[ 'driverName' ], 
-            obj[ 'username' ],
-            obj[ 'password' ],
-            obj[ 'hostname' ],
-            obj[ 'port' ],
-            obj[ 'database' ],
-            obj[ 'parameters' ],
+            obj[ 'driverName' ] || obj[ 'DriverName' ], 
+            obj[ 'username' ]   || obj[ 'Username' ],
+            obj[ 'password' ]   || obj[ 'Password' ],
+            obj[ 'hostname' ]   || obj[ 'Hostname' ],
+            obj[ 'port' ]       || obj[ 'Port' ],
+            obj[ 'database' ]   || obj[ 'Database' ],
+            obj[ 'parameters' ] || obj[ 'Parameters' ],
             driver
         );
     }

--- a/lib/dynamicPool.js
+++ b/lib/dynamicPool.js
@@ -4,7 +4,18 @@ var ParseConnection = require('./parseConnection');
 
 class DynamicPool {
 
-    constructor(url, poolSize =  10, driver = undefined) {
+    /**
+     * Constructs a dynamic pool.
+     * 
+     * @param {string|ConnectionObject} conn Connection string or object.
+     * @param {int} poolSize Pool size (optional).
+     * @param {any} driver Driver to use (optional).
+     * @memberof DynamicPool
+     */
+    constructor(conn, poolSize =  10, driver = undefined) {
+
+        let url = 'string' === typeof conn ? conn : conn.makeURL();
+
         /** @type {string} */
         this.__url = url;
         /** @type {number} */

--- a/lib/staticPool.js
+++ b/lib/staticPool.js
@@ -7,7 +7,18 @@ var InUsePool = {};
 
 class StaticPool {
 
-    constructor(url, poolSize =  10, driver = undefined) {
+    /**
+     * Constructs a static pool.
+     * 
+     * @param {string|ConnectionObject} conn Connection string or object.
+     * @param {int} poolSize Pool size (optional).
+     * @param {any} driver Driver to use (optional).
+     * @memberof StaticPool
+     */    
+    constructor(conn, poolSize =  10, driver = undefined) {
+
+        let url = 'string' === typeof conn ? conn : conn.makeURL();
+
         if (url in AvailablePool === false) {
             AvailablePool[url] = [];
         }


### PR DESCRIPTION
- `Connection`'s constructor now accepts a connection string or a `ConnectionObject`.
- `ConnectionObject` now has the methods `makeURL()` and `fromPlain(obj)`.
- `DynamicPool` and `StaticPool` now accept both a connection string or a `ConnectionObject`.